### PR TITLE
feat: 支持 details 折叠块并修复甘特图渲染

### DIFF
--- a/src/components/markdown-editor/editorExtensions.js
+++ b/src/components/markdown-editor/editorExtensions.js
@@ -21,6 +21,7 @@ import { MermaidBlock } from '../../extensions/MermaidBlock.js';
 import { VideoBlock } from '../../extensions/VideoBlock.js';
 import { CsvTableNode } from '../../extensions/CsvTableNode.js';
 import { MathBlock, MathInline } from '../../extensions/MathBlock.js';
+import { DetailsBlock, DetailsSummary } from '../../extensions/DetailsBlock.js';
 import { DisableInlineCodeShortcut } from '../../extensions/DisableInlineCodeShortcut.js';
 import { SourcePos } from '../../extensions/SourcePos.js';
 import { TableSelectionGuard } from '../../extensions/TableSelectionGuard.js';
@@ -138,6 +139,8 @@ export function createEditorExtensions(lowlight) {
         CsvTableNode,
         MathBlock,
         MathInline,
+        DetailsBlock,
+        DetailsSummary,
         SourcePos,
         CodeBlockLowlight.configure({
             lowlight,

--- a/src/extensions/DetailsBlock.js
+++ b/src/extensions/DetailsBlock.js
@@ -1,0 +1,126 @@
+import { mergeAttributes, Node } from '@tiptap/core';
+
+/**
+ * 合并内部结构类名与用户类名，避免重复写入 details-block。
+ * @param {unknown} userClass - 用户提供的 class 属性
+ * @returns {string}
+ */
+function normalizeDetailsClassName(userClass) {
+    const classNames = typeof userClass === 'string' ? userClass.split(/\s+/).filter(Boolean) : [];
+    return Array.from(new Set(['details-block', ...classNames])).join(' ');
+}
+
+/**
+ * 把 details 节点属性同步到 NodeView DOM，并保留用户提供的基础 HTML 属性。
+ * @param {HTMLDetailsElement} element - 折叠块 DOM
+ * @param {Record<string, unknown>} attrs - ProseMirror 节点属性
+ */
+function applyDetailsAttributes(element, attrs) {
+    element.className = normalizeDetailsClassName(attrs.class);
+    element.dataset.type = 'details-block';
+    element.open = attrs.open === true;
+
+    if (attrs.id) element.id = String(attrs.id);
+    else element.removeAttribute('id');
+
+    if (attrs.style) element.setAttribute('style', String(attrs.style));
+    else element.removeAttribute('style');
+}
+
+/**
+ * 原生 `<details>` 折叠块。
+ * summary 由第一个 detailsSummary 子节点承载，后续 block 子节点继续使用标准 Markdown 结构。
+ */
+export const DetailsBlock = Node.create({
+    name: 'detailsBlock',
+    group: 'block',
+    content: 'detailsSummary block*',
+    defining: true,
+    isolating: true,
+
+    addAttributes() {
+        return {
+            open: {
+                default: false,
+                parseHTML: element => element.hasAttribute('open'),
+                renderHTML: attributes => (attributes.open ? { open: '' } : {}),
+            },
+            id: {
+                default: null,
+                parseHTML: element => element.getAttribute('id'),
+            },
+            class: {
+                default: null,
+                parseHTML: element => element.getAttribute('class'),
+            },
+            style: {
+                default: null,
+                parseHTML: element => element.getAttribute('style'),
+            },
+        };
+    },
+
+    parseHTML() {
+        return [{ tag: 'details' }];
+    },
+
+    renderHTML({ HTMLAttributes }) {
+        const { class: userClass, ...attributes } = HTMLAttributes;
+        return [
+            'details',
+            mergeAttributes(
+                { 'data-type': 'details-block' },
+                attributes,
+                { class: normalizeDetailsClassName(userClass) }
+            ),
+            0,
+        ];
+    },
+
+    addNodeView() {
+        return ({ node }) => {
+            const dom = document.createElement('details');
+            let currentNode = node;
+            applyDetailsAttributes(dom, currentNode.attrs);
+
+            return {
+                dom,
+                contentDOM: dom,
+                update(nextNode) {
+                    if (nextNode.type !== currentNode.type) return false;
+
+                    // 用户点击 summary 产生的展开状态只属于当前视图，不应自动改写 Markdown。
+                    // 只有文档本身的 open 属性变化时，才覆盖 DOM 的临时展开状态。
+                    const documentOpenChanged = nextNode.attrs.open !== currentNode.attrs.open;
+                    const transientOpen = dom.open;
+                    currentNode = nextNode;
+                    applyDetailsAttributes(dom, currentNode.attrs);
+                    if (!documentOpenChanged) dom.open = transientOpen;
+                    return true;
+                },
+                ignoreMutation(mutation) {
+                    return mutation.type === 'attributes'
+                        && mutation.target === dom
+                        && mutation.attributeName === 'open';
+                },
+            };
+        };
+    },
+});
+
+/**
+ * `<summary>` 标题节点，只允许行内内容，并且只能作为 detailsBlock 的第一个子节点出现。
+ */
+export const DetailsSummary = Node.create({
+    name: 'detailsSummary',
+    content: 'inline*',
+    defining: true,
+
+    parseHTML() {
+        return [{ tag: 'summary' }];
+    },
+
+    renderHTML() {
+        return ['summary', { class: 'details-block__summary' }, 0];
+    },
+});

--- a/src/extensions/SourcePos.js
+++ b/src/extensions/SourcePos.js
@@ -25,6 +25,7 @@ export const SourcePos = Extension.create({
                     'tableHeader',
                     'mermaidBlock',
                     'videoBlock',
+                    'detailsBlock',
                     'image',
                 ],
                 attributes: {

--- a/src/modules/detailsBlockMarkdown.js
+++ b/src/modules/detailsBlockMarkdown.js
@@ -1,0 +1,131 @@
+const DETAILS_OPEN_RE = /^<details(?:\s[^>]*)?>\s*$/i;
+const DETAILS_CLOSE_RE = /^<\/details>\s*$/i;
+const SUMMARY_OPEN_RE = /^<summary(?:\s[^>]*)?>/i;
+const SUMMARY_BLOCK_RE = /^<summary(?:\s[^>]*)?>([\s\S]*?)<\/summary>\s*$/i;
+
+/**
+ * 读取 MarkdownIt 指定行去掉当前块缩进后的原始文本。
+ * @param {object} state - MarkdownIt StateBlock
+ * @param {number} line - 零基行号
+ * @returns {string}
+ */
+function getLineText(state, line) {
+    const start = state.bMarks[line] + state.tShift[line];
+    return state.src.slice(start, state.eMarks[line]);
+}
+
+/**
+ * 从 HTML 开始标签中读取一个基础属性值。
+ * @param {string} openingTag - HTML 开始标签
+ * @param {string} name - 属性名
+ * @returns {string|null}
+ */
+function readHtmlAttribute(openingTag, name) {
+    const pattern = new RegExp(`(?:^|\\s)${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s>]+))`, 'i');
+    const match = openingTag.match(pattern);
+    return match ? (match[1] ?? match[2] ?? match[3] ?? '') : null;
+}
+
+/**
+ * 从 details 开始标签中提取需要往返保存的基础属性。
+ * @param {string} openingTag - 完整 details 开始标签
+ * @returns {{open:boolean,id:string|null,class:string|null,style:string|null}}
+ */
+function parseDetailsAttributes(openingTag) {
+    return {
+        open: /(?:^|\s)open(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+))?(?=\s|>)/i.test(openingTag),
+        id: readHtmlAttribute(openingTag, 'id'),
+        class: readHtmlAttribute(openingTag, 'class'),
+        style: readHtmlAttribute(openingTag, 'style'),
+    };
+}
+
+/**
+ * 查找与开始行配对的 details 结束行，支持独立成行的嵌套 details。
+ * @param {object} state - MarkdownIt StateBlock
+ * @param {number} startLine - details 开始行
+ * @param {number} endLine - 当前块解析上界
+ * @returns {number}
+ */
+function findDetailsCloseLine(state, startLine, endLine) {
+    let depth = 1;
+    for (let line = startLine + 1; line < endLine; line += 1) {
+        const text = getLineText(state, line).trim();
+        if (DETAILS_OPEN_RE.test(text)) depth += 1;
+        if (!DETAILS_CLOSE_RE.test(text)) continue;
+        depth -= 1;
+        if (depth === 0) return line;
+    }
+    return -1;
+}
+
+/**
+ * 读取 details 的 summary，允许 summary 内容跨越多行。
+ * @param {object} state - MarkdownIt StateBlock
+ * @param {number} startLine - details 开始行
+ * @param {number} closeLine - details 结束行
+ * @returns {{content:string,startLine:number,endLine:number}|null}
+ */
+function readDetailsSummary(state, startLine, closeLine) {
+    let summaryStart = startLine + 1;
+    while (summaryStart < closeLine && state.isEmpty(summaryStart)) summaryStart += 1;
+    if (summaryStart >= closeLine || !SUMMARY_OPEN_RE.test(getLineText(state, summaryStart).trim())) {
+        return null;
+    }
+
+    for (let line = summaryStart; line < closeLine; line += 1) {
+        const source = state.getLines(summaryStart, line + 1, state.blkIndent, true).trim();
+        const match = source.match(SUMMARY_BLOCK_RE);
+        if (match) {
+            return {
+                content: match[1].trim(),
+                startLine: summaryStart,
+                endLine: line + 1,
+            };
+        }
+    }
+    return null;
+}
+
+/**
+ * 注册 details 专用块规则，让跨多个 Markdown block 的折叠内容保持正确嵌套。
+ * @param {import('markdown-it')} md - MarkdownIt 实例
+ */
+export function addDetailsBlockMarkdownRule(md) {
+    md.block.ruler.before('html_block', 'details_block', (state, startLine, endLine, silent) => {
+        if (state.sCount[startLine] - state.blkIndent >= 4) return false;
+
+        const openingTag = getLineText(state, startLine).trim();
+        if (!DETAILS_OPEN_RE.test(openingTag)) return false;
+
+        const closeLine = findDetailsCloseLine(state, startLine, endLine);
+        if (closeLine < 0) return false;
+
+        const summary = readDetailsSummary(state, startLine, closeLine);
+        if (!summary) return false;
+        if (silent) return true;
+
+        const detailsOpen = state.push('details_open', 'details', 1);
+        detailsOpen.map = [startLine, closeLine + 1];
+        detailsOpen.meta = { attrs: parseDetailsAttributes(openingTag) };
+
+        const summaryOpen = state.push('details_summary_open', 'summary', 1);
+        summaryOpen.map = [summary.startLine, summary.endLine];
+
+        const inline = state.push('inline', '', 0);
+        inline.content = summary.content;
+        inline.map = [summary.startLine, summary.endLine];
+        inline.children = [];
+
+        state.push('details_summary_close', 'summary', -1);
+
+        const bodyStartLine = summary.endLine;
+        if (bodyStartLine < closeLine) {
+            state.md.block.tokenize(state, bodyStartLine, closeLine);
+        }
+
+        state.push('details_close', 'details', -1);
+        state.line = closeLine + 1;
+        return true;
+    }, { alt: ['paragraph', 'reference', 'blockquote', 'list'] });
+}

--- a/src/modules/markdownPipeline.js
+++ b/src/modules/markdownPipeline.js
@@ -6,6 +6,7 @@ import katex from 'katex';
 import { MarkdownParser, MarkdownSerializer, MarkdownSerializerState } from 'prosemirror-markdown';
 import { DOMParser as PMDOMParser } from '@tiptap/pm/model';
 import { markdownItCjkEmphasis } from '../utils/markdownItCjkEmphasis.js';
+import { addDetailsBlockMarkdownRule } from './detailsBlockMarkdown.js';
 
 function listIsTight(tokens, i) {
     while (++i < tokens.length) {
@@ -102,6 +103,9 @@ function createMarkdownTokenizer() {
     });
 
     md.use(markdownItCjkEmphasis);
+
+    // details 必须在通用 html_block 之前识别，否则开始/正文/结束会被拆成互不关联的块。
+    addDetailsBlockMarkdownRule(md);
 
     md.use(texmath, {
         engine: katex,
@@ -284,6 +288,14 @@ export function createMarkdownParser(schema) {
         math_inline_double: { node: 'mathBlock', noCloseToken: true, getAttrs: tok => ({ latex: tok.content || '' }) },
         math_block: { node: 'mathBlock', noCloseToken: true, getAttrs: tok => ({ latex: tok.content || '' }) },
         math_block_eqno: { node: 'mathBlock', noCloseToken: true, getAttrs: tok => ({ latex: tok.content || '' }) },
+        details: {
+            block: 'detailsBlock',
+            getAttrs: tok => ({
+                ...(tok.meta?.attrs || {}),
+                sourcepos: getSourcepos(tok),
+            }),
+        },
+        details_summary: { block: 'detailsSummary' },
     };
 
     const parser = new MarkdownParser(schema, tokenizer, tokens);
@@ -599,6 +611,21 @@ function renderInlineContent(state, node) {
     return subState.out.trim();
 }
 
+/**
+ * 从指定子节点开始序列化块级内容，供 details 等自带结构标签的容器复用。
+ * @param {MarkdownSerializerState} state - 当前序列化状态
+ * @param {import('@tiptap/pm/model').Node} parent - 父节点
+ * @param {number} startIndex - 首个需要序列化的子节点索引
+ * @returns {string}
+ */
+function renderBlockContentFrom(state, parent, startIndex) {
+    const subState = new MarkdownSerializerState(state.nodes, state.marks, state.options);
+    for (let index = startIndex; index < parent.childCount; index += 1) {
+        subState.render(parent.child(index), parent, index);
+    }
+    return subState.out.trimEnd();
+}
+
 export function createMarkdownSerializer(schema) {
     void schema;
     const nodes = {
@@ -725,6 +752,22 @@ export function createMarkdownSerializer(schema) {
         mathInline(state, node) {
             const latex = node.attrs?.latex || '';
             state.write(`$${latex}$`);
+        },
+        detailsBlock(state, node) {
+            const summaryNode = node.firstChild;
+            const summary = summaryNode ? renderInlineContent(state, summaryNode) : '';
+            const body = renderBlockContentFrom(state, node, 1);
+            const { open, sourcepos, ...htmlAttrs } = node.attrs || {};
+            void sourcepos;
+            const attributes = `${open ? ' open' : ''}${serializeHtmlAttributes(htmlAttrs)}`;
+            let markdown = `<details${attributes}>\n<summary>${summary}</summary>`;
+            if (body) markdown += `\n\n${body}`;
+            markdown += '\n</details>';
+            state.text(markdown, false);
+            state.closeBlock(node);
+        },
+        detailsSummary(state, node) {
+            state.renderInline(node, false);
         },
         image(state, node) {
             const alt = state.esc(node.attrs?.alt || '');

--- a/src/utils/mermaidRenderer.js
+++ b/src/utils/mermaidRenderer.js
@@ -1,6 +1,10 @@
 let mermaidPromise = null;
 let mermaidInstance = null;
 
+// Mermaid 的 Gantt 等图表会读取渲染宿主宽度计算 viewBox。这里使用稳定宽度，
+// 既避免宿主随窗口变化导致同一份缓存产生不同 SVG，也覆盖编辑器允许的最大页面宽度。
+const MERMAID_RENDER_HOST_WIDTH = 1200;
+
 // mermaid.render(id, text) 不传第三个参数时，它会把临时渲染 div 直接挂到 document.body 上。
 // body 是 display:flex; flex-wrap:wrap，这个临时 div 会立刻成为 flex item，布局成右侧
 // 一个 column 闪一下再被自身 remove —— 这是"打开 md 文件时右侧 200px 空 column 闪现"
@@ -10,7 +14,7 @@ function getMermaidRenderHost() {
     if (_mermaidHost && _mermaidHost.isConnected) return _mermaidHost;
     _mermaidHost = document.createElement('div');
     _mermaidHost.id = 'mermaid-offscreen-host';
-    _mermaidHost.style.cssText = 'position:fixed;left:-9999px;top:0;width:0;height:0;visibility:hidden;pointer-events:none;overflow:hidden;';
+    _mermaidHost.style.cssText = `position:fixed;left:-9999px;top:0;width:${MERMAID_RENDER_HOST_WIDTH}px;height:0;visibility:hidden;pointer-events:none;overflow:hidden;`;
     document.body.appendChild(_mermaidHost);
     return _mermaidHost;
 }
@@ -1017,6 +1021,7 @@ async function renderSingleMermaid(element) {
             element.innerHTML = cached.svg;
             const svgElement = element.querySelector('svg');
             if (svgElement) {
+                svgElement.style.maxWidth = '100%';
                 stripSvgBackground(svgElement);
                 polishFlowchart(svgElement);
                 polishSequence(svgElement);
@@ -1049,6 +1054,7 @@ async function renderSingleMermaid(element) {
             svgElement.setAttribute('preserveAspectRatio', 'xMidYMid meet');
             svgElement.style.overflow = 'visible';
             svgElement.style.display = 'block';
+            svgElement.style.maxWidth = '100%';
             svgElement.style.background = 'transparent';
 
             // 移除 mermaid 内部的背景矩形

--- a/styles/editor.css
+++ b/styles/editor.css
@@ -999,6 +999,29 @@
     font-style: italic;
 }
 
+/* 原生 details 折叠块：只定义结构，颜色保持跟随当前编辑器主题。 */
+.tiptap-editor .details-block {
+    margin: 1em 0;
+    padding: 0.75em 1em;
+    border: 1px solid rgba(127, 127, 127, 0.24);
+    border-radius: 6px;
+    background: rgba(127, 127, 127, 0.04);
+}
+
+.tiptap-editor .details-block__summary {
+    cursor: pointer;
+    font-weight: 600;
+    outline: none;
+}
+
+.tiptap-editor .details-block[open] > .details-block__summary {
+    margin-bottom: 0.75em;
+}
+
+.tiptap-editor .details-block > :last-child {
+    margin-bottom: 0;
+}
+
 /* 列表 */
 .tiptap-editor ul,
 .tiptap-editor ol {

--- a/tests/detailsBlockMarkdown.test.js
+++ b/tests/detailsBlockMarkdown.test.js
@@ -1,0 +1,84 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import MarkdownIt from 'markdown-it';
+import { addDetailsBlockMarkdownRule } from '../src/modules/detailsBlockMarkdown.js';
+
+/**
+ * 创建仅加载 details 块规则的 MarkdownIt 测试实例。
+ * @returns {MarkdownIt}
+ */
+function createDetailsMarkdownIt() {
+    const md = new MarkdownIt({ html: true, breaks: true });
+    addDetailsBlockMarkdownRule(md);
+    return md;
+}
+
+test('details 块保留 summary、正文 Markdown 和基础属性', () => {
+    const md = createDetailsMarkdownIt();
+    const source = `<details open class="faq" id="answer">
+<summary>**点击**查看</summary>
+
+正文段落
+
+- 项目一
+- 项目二
+</details>`;
+
+    const tokens = md.parse(source, {});
+    assert.deepEqual(tokens.map(token => token.type), [
+        'details_open',
+        'details_summary_open',
+        'inline',
+        'details_summary_close',
+        'paragraph_open',
+        'inline',
+        'paragraph_close',
+        'bullet_list_open',
+        'list_item_open',
+        'paragraph_open',
+        'inline',
+        'paragraph_close',
+        'list_item_close',
+        'list_item_open',
+        'paragraph_open',
+        'inline',
+        'paragraph_close',
+        'list_item_close',
+        'bullet_list_close',
+        'details_close',
+    ]);
+    assert.deepEqual(tokens[0].meta.attrs, {
+        open: true,
+        id: 'answer',
+        class: 'faq',
+        style: null,
+    });
+    assert.equal(tokens[2].content, '**点击**查看');
+});
+
+test('details 块支持嵌套且不会被通用 HTML 规则拆散', () => {
+    const md = createDetailsMarkdownIt();
+    const source = `<details>
+<summary>外层</summary>
+
+<details>
+<summary>内层</summary>
+
+内容
+</details>
+</details>`;
+
+    const tokens = md.parse(source, {});
+    assert.equal(tokens.filter(token => token.type === 'details_open').length, 2);
+    assert.equal(tokens.filter(token => token.type === 'details_close').length, 2);
+    assert.equal(tokens.filter(token => token.type === 'details_summary_open').length, 2);
+    assert.equal(tokens.some(token => token.type === 'html_block'), false);
+});
+
+test('不完整 details 继续交给原有 HTML 兜底规则处理', () => {
+    const md = createDetailsMarkdownIt();
+    const tokens = md.parse('<details>\n<summary>缺少结束标签</summary>\n', {});
+
+    assert.equal(tokens.some(token => token.type === 'details_open'), false);
+    assert.equal(tokens.some(token => token.type === 'html_block'), true);
+});

--- a/tests/fixtures/issue-19-gantt-details.md
+++ b/tests/fixtures/issue-19-gantt-details.md
@@ -1,0 +1,93 @@
+# Issue #19：甘特图与折叠块测试
+
+本文档用于验证 Mermaid 甘特图和 `<details>` 折叠块在 Mark2 预览模式下的行为。
+
+## 1. Mermaid 甘特图
+
+预期：下方显示完整甘特图，宽度不为零；调整窗口宽度后图表保持可见。
+
+```mermaid
+gantt
+    title Mark2 v1.7.54 功能验证
+    dateFormat YYYY-MM-DD
+    axisFormat %m-%d
+
+    section 修复
+    定位问题       :done, diagnose, 2026-08-17, 1d
+    修复甘特图     :done, gantt-fix, after diagnose, 1d
+    支持折叠块     :done, details, after diagnose, 2d
+
+    section 验证
+    macOS 测试     :active, mac-test, after gantt-fix, 1d
+    Windows 冒烟   :win-test, after mac-test, 1d
+    发布           :milestone, release, after win-test, 0d
+```
+
+## 2. 默认收起
+
+预期：首次显示为收起状态，点击标题后显示正文，再次点击可以收起。
+
+<details id="closed-example" class="test-details">
+<summary>点击展开默认收起的内容</summary>
+
+这里是默认收起的正文。
+
+- 支持普通段落
+- 支持 **加粗文字**
+- 支持 `inline code`
+- 支持 [链接](https://example.com)
+
+</details>
+
+## 3. 默认展开
+
+预期：首次加载时正文可见，点击标题可以收起。
+
+<details open>
+<summary>默认展开的内容</summary>
+
+这段内容应该在文档打开时直接显示。
+
+> 折叠块正文中的引用也应正常渲染。
+
+```javascript
+function detailsTest() {
+    return 'code block inside details';
+}
+```
+
+</details>
+
+## 4. 嵌套折叠
+
+预期：外层和内层可以分别展开、收起，互不影响。
+
+<details>
+<summary>外层折叠块</summary>
+
+外层正文。
+
+<details>
+<summary>内层折叠块</summary>
+
+内层正文，包含一个任务列表：
+
+- [x] 解析为独立节点
+- [x] 点击可以折叠
+- [ ] Windows 最终冒烟测试
+
+</details>
+
+外层折叠块末尾内容。
+
+</details>
+
+## 5. 往返保存检查
+
+请完成以下操作：
+
+1. 分别展开、收起上面的折叠块。
+2. 切换到源码模式，再切回预览模式。
+3. 在某个折叠块正文中修改一行文字并保存。
+4. 重新打开本文档。
+5. 确认 Mermaid 仍可见，`<details open>` 仍默认展开，嵌套内容和 Markdown 格式没有丢失。


### PR DESCRIPTION
## 变更

- 支持 Markdown `<details>/<summary>` 折叠块、嵌套内容及属性往返保存
- 修复 Mermaid Gantt 在离屏零宽容器中生成空白/窄图的问题
- 添加 details 解析测试与 Issue #19 手动测试文档

## 验证

- `npm test`：45/45 通过
- `npm run build`：通过
- macOS Tauri Release 实机验证折叠交互与甘特图显示

Closes #19