### PR TITLE
fix(deps): remove unused js-yaml and update linkify-it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "mark2-tauri",
-  "version": "1.7.43",
+  "version": "1.7.57",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mark2-tauri",
-      "version": "1.7.43",
+      "version": "1.7.57",
+      "license": "MIT",
       "dependencies": {
         "@codemirror/commands": "^6.8.1",
         "@codemirror/lang-cpp": "^6.0.3",
@@ -49,7 +50,6 @@
         "@tiptap/starter-kit": "^3.13.0",
         "codemirror": "^6.0.2",
         "highlight.js": "^11.11.1",
-        "js-yaml": "^4.1.1",
         "jszip": "^3.10.1",
         "katex": "^0.16.35",
         "lowlight": "^3.3.0",
@@ -3572,18 +3572,6 @@
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
     },
-    "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/jszip": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
@@ -3666,9 +3654,19 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "@tiptap/starter-kit": "^3.13.0",
     "codemirror": "^6.0.2",
     "highlight.js": "^11.11.1",
-    "js-yaml": "^4.1.1",
     "jszip": "^3.10.1",
     "katex": "^0.16.35",
     "lowlight": "^3.3.0",


### PR DESCRIPTION
## Summary

- remove the unused direct `js-yaml` dependency, eliminating GHSA-5p4m-2wfm-xmqj from the dependency tree
- update transitive `linkify-it` from 5.0.0 to 5.0.2 without a permanent override, fixing CVE-2026-48801 and the related 5.0.1 advisory
- align the root lockfile metadata with package version 1.7.57

This cleanly replaces #21 and #25 without their stale lockfile metadata or mutual merge conflict.

## Validation

- `npm ci`
- `npm run build`
- `npm audit --omit=dev`: the targeted high-severity advisories are gone; only three existing moderate dependency groups remain
- `npm test`: 58 passed, 3 pre-existing pane-layout tests failed identically on the current baseline